### PR TITLE
Correct URL from main page to Provider View

### DIFF
--- a/dashboards/grid.json
+++ b/dashboards/grid.json
@@ -346,7 +346,7 @@
         {
           "targetBlank": true,
           "title": "Provider View",
-          "url": "../d/TExgjgJZk/provider-view"
+          "url": "../d/TEXgjgJZk/provider-view"
         }
       ],
       "maxDataPoints": 3,


### PR DESCRIPTION
`X` rather than `x`!