### PR TITLE
Improve clarity of units

### DIFF
--- a/dashboards/activity_view.json
+++ b/dashboards/activity_view.json
@@ -224,7 +224,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Elapsed time * Number of Processors (months) by VO and Month",
+      "title": "Average Core Usage by Activity and Month",
       "tooltip": {
         "shared": false,
         "sort": 0,
@@ -409,7 +409,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Elapsed time (months) by VO and Month",
+      "title": "Elapsed time (months) by Activity and Month",
       "tooltip": {
         "shared": false,
         "sort": 0,
@@ -593,7 +593,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "CPU time (months) by VO and Month",
+      "title": "CPU time (months) by Activity and Month",
       "tooltip": {
         "shared": false,
         "sort": 0,
@@ -680,7 +680,7 @@
         "definition": "SELECT name FROM VAllVOs WHERE (name <> 'DAFNI') AND (name <> 'None')",
         "hide": 0,
         "includeAll": true,
-        "label": "VO",
+        "label": "Activity",
         "multi": true,
         "name": "All_VOs",
         "options": [],

--- a/dashboards/grid.json
+++ b/dashboards/grid.json
@@ -240,7 +240,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Elapsed time * Number of Processors (months) by VO and Month",
+      "title": "Average Core Usage by Activity and Month",
       "tooltip": {
         "shared": false,
         "sort": 0,
@@ -426,7 +426,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Elapsed time * Number of Processors (months) by Site",
+      "title": "Average Core Usage by Site",
       "type": "grafana-piechart-panel",
       "valueName": "total"
     },
@@ -579,7 +579,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Elapsed time * Number of Processors (months) by VO",
+      "title": "Average Core Usage by Activity",
       "type": "grafana-piechart-panel",
       "valueName": "total"
     }
@@ -634,7 +634,7 @@
         "definition": "SELECT name FROM VAllVOs WHERE (name <> 'DAFNI') AND (name <> 'None')",
         "hide": 0,
         "includeAll": true,
-        "label": "VO",
+        "label": "Activity",
         "multi": true,
         "name": "All_VOs",
         "options": [],

--- a/dashboards/provider_view.json
+++ b/dashboards/provider_view.json
@@ -226,7 +226,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Elapsed time * Number of Processors (months) by Site and Month",
+      "title": "Average Core Usage by Site and Month",
       "tooltip": {
         "shared": false,
         "sort": 0,
@@ -951,7 +951,7 @@
         "definition": "SELECT name FROM VAllVOs WHERE (name <> 'DAFNI') AND (name <> 'None')",
         "hide": 0,
         "includeAll": true,
-        "label": "VO",
+        "label": "Activity",
         "multi": true,
         "name": "All_VOs",
         "options": [],

--- a/dashboards/resource_manager.json
+++ b/dashboards/resource_manager.json
@@ -698,7 +698,7 @@
         "definition": "SELECT name FROM VAllVOs WHERE (name <> 'DAFNI')",
         "hide": 0,
         "includeAll": true,
-        "label": "VO",
+        "label": "Activity",
         "multi": true,
         "name": "All_VOs",
         "options": [],


### PR DESCRIPTION
Change to "Average Core Usage by..." and "Activity" instead of "VO". Resolves #3.