### PR TITLE
Fix projection graph

### DIFF
--- a/dashboards/resource_manager.json
+++ b/dashboards/resource_manager.json
@@ -473,11 +473,12 @@
       "gridPos": {
         "h": 10,
         "w": 4,
-        "x": 9,
+        "x": 13,
         "y": 0
       },
+      "hiddenSeries": false,
       "hideTimeOverride": true,
-      "id": 16,
+      "id": 17,
       "interval": "",
       "legend": {
         "alignAsTable": false,

--- a/dashboards/resource_manager.json
+++ b/dashboards/resource_manager.json
@@ -405,7 +405,6 @@
       },
       "yaxes": [
         {
-          "decimals": 2,
           "format": "short",
           "label": "",
           "logBase": 1,


### PR DESCRIPTION
Change ID and coordinates to stop graphs overlapping. Remove decimal places definition so that the graphs match.

This fixes an issue that slipped in with #56.