### PR TITLE
Add decimal place to pie chart percentages

### DIFF
--- a/dashboards/grid.json
+++ b/dashboards/grid.json
@@ -374,7 +374,7 @@
       "legend": {
         "header": "",
         "percentage": true,
-        "percentageDecimals": null,
+        "percentageDecimals": 1,
         "show": true,
         "sideWidth": null,
         "sort": "total",
@@ -528,7 +528,7 @@
       "legend": {
         "header": "",
         "percentage": true,
-        "percentageDecimals": null,
+        "percentageDecimals": 1,
         "show": true,
         "sideWidth": null,
         "sort": "total",


### PR DESCRIPTION
This is to enable the percentages to be distinguished more easily as
there are quite a few that show as the same percentage when no decimal
places are shown.