### PR TITLE
json changes to group pie chart slices below a certain value

### DIFF
--- a/dashboards/iris/iris.json
+++ b/dashboards/iris/iris.json
@@ -312,8 +312,8 @@
       "breakPoint": "50%",
       "cacheTimeout": null,
       "combine": {
-        "label": "Others",
-        "threshold": "0"
+        "label": "Others ≤1.0%",
+        "threshold": "0.011"
       },
       "datasource": "-- Mixed --",
       "decimals": null,
@@ -442,8 +442,8 @@
       "breakPoint": "50%",
       "cacheTimeout": null,
       "combine": {
-        "label": "Others",
-        "threshold": "0"
+        "label": "Others ≤1.0%",
+        "threshold": "0.011"
       },
       "datasource": "-- Mixed --",
       "decimals": null,

--- a/dashboards/iris/iris.json
+++ b/dashboards/iris/iris.json
@@ -313,7 +313,7 @@
       "cacheTimeout": null,
       "combine": {
         "label": "Others ≤1.0%",
-        "threshold": "0.011"
+        "threshold": "0.0110"
       },
       "datasource": "-- Mixed --",
       "decimals": null,
@@ -443,7 +443,7 @@
       "cacheTimeout": null,
       "combine": {
         "label": "Others ≤1.0%",
-        "threshold": "0.011"
+        "threshold": "0.0110"
       },
       "datasource": "-- Mixed --",
       "decimals": null,

--- a/dashboards/iris/iris.json
+++ b/dashboards/iris/iris.json
@@ -312,8 +312,8 @@
       "breakPoint": "50%",
       "cacheTimeout": null,
       "combine": {
-        "label": "Others ≤1.0%",
-        "threshold": "0.0110"
+        "label": "Others ≤0.5%",
+        "threshold": "0.005"
       },
       "datasource": "-- Mixed --",
       "decimals": null,
@@ -443,7 +443,7 @@
       "cacheTimeout": null,
       "combine": {
         "label": "Others ≤1.0%",
-        "threshold": "0.0110"
+        "threshold": "0.010"
       },
       "datasource": "-- Mixed --",
       "decimals": null,


### PR DESCRIPTION
Closes #110 

Small code change that will group pie chart values below 1% on the IRIS Accounting Dashboard 

![PieCharts](https://user-images.githubusercontent.com/44807020/119986899-5114b300-bfbc-11eb-90b4-10c997108ae7.PNG)
