### PR TITLE
Added Job Time Ratios (CPU efficiency) to dashboards

### DIFF
--- a/dashboards/iris/activity_view.json
+++ b/dashboards/iris/activity_view.json
@@ -24,7 +24,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 4,
   "links": [
     {
       "asDropdown": false,
@@ -46,6 +45,230 @@
   ],
   "liveNow": false,
   "panels": [
+    {
+      "datasource": {
+        "type": "mysql",
+        "uid": "P4815E41304F4136B"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "custom": {
+            "fillOpacity": 100,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "from": 0,
+                "result": {
+                  "color": "#f53535",
+                  "index": 0,
+                  "text": "0-10"
+                },
+                "to": 10
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 10,
+                "result": {
+                  "color": "#ec5d35",
+                  "index": 1,
+                  "text": "10-20"
+                },
+                "to": 20
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 20,
+                "result": {
+                  "color": "#e48134",
+                  "index": 2,
+                  "text": "20-30"
+                },
+                "to": 30
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 30,
+                "result": {
+                  "color": "#dca233",
+                  "index": 3,
+                  "text": "30-40"
+                },
+                "to": 40
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 40,
+                "result": {
+                  "color": "#d4bf32",
+                  "index": 4,
+                  "text": "40-50"
+                },
+                "to": 50
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 50,
+                "result": {
+                  "color": "#becc31",
+                  "index": 5,
+                  "text": "50-60"
+                },
+                "to": 60
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 60,
+                "result": {
+                  "color": "#96c430",
+                  "index": 6,
+                  "text": "60-70"
+                },
+                "to": 70
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 70,
+                "result": {
+                  "color": "#72bc2f",
+                  "index": 7,
+                  "text": "70-80"
+                },
+                "to": 80
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 80,
+                "result": {
+                  "color": "#50b42e",
+                  "index": 8,
+                  "text": "80-90"
+                },
+                "to": 90
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 90,
+                "result": {
+                  "color": "#32ac2d",
+                  "index": 9,
+                  "text": "90-100"
+                },
+                "to": 100
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 100,
+                "result": {
+                  "color": "#2fe4ff",
+                  "index": 10,
+                  "text": "100+"
+                },
+                "to": null
+              },
+              "type": "range"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 17,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": false,
+        "rowHeight": 0.8,
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "dataset": "iris_storage",
+          "datasource": {
+            "type": "mysql",
+            "uid": "P4815E41304F4136B"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  Date as \"time\",\n  VO,\n  SUM(CpuDuration)/SUM(WallDuration*CpuCount)*100 AS \"\"\nFROM VCombinedSummaries\nWHERE\n  $__timeFilter(Date) and Project in ($Project) and Site in ($Site) and VO in ($VO) and SourceSchema in ($Source) and VOGroup in ($VOGroup)\nGROUP BY 1,2\nORDER BY Date",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Job Time Ratios",
+      "type": "state-timeline"
+    },
     {
       "aliasColors": {
         "AENEAS": "#f58231",
@@ -917,7 +1140,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 11
       },
       "hiddenSeries": false,
       "id": 2,
@@ -936,14 +1159,13 @@
       },
       "lines": false,
       "linewidth": 1,
-      "links": [],
       "nullPointMode": "null as zero",
       "options": {
         "alertThreshold": true
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.4.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1951,7 +2173,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 12
+        "y": 23
       },
       "hiddenSeries": false,
       "id": 4,
@@ -1968,14 +2190,13 @@
       },
       "lines": false,
       "linewidth": 1,
-      "links": [],
       "nullPointMode": "null as zero",
       "options": {
         "alertThreshold": true
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.4.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2939,7 +3160,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 12
+        "y": 23
       },
       "hiddenSeries": false,
       "id": 6,
@@ -2954,14 +3175,13 @@
       },
       "lines": false,
       "linewidth": 1,
-      "links": [],
       "nullPointMode": "null as zero",
       "options": {
         "alertThreshold": true
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.4.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3129,7 +3349,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3940,10 +4161,11 @@
         "h": 17,
         "w": 12,
         "x": 0,
-        "y": 21
+        "y": 32
       },
       "id": 8,
       "options": {
+        "cellHeight": "sm",
         "footer": {
           "countRows": false,
           "fields": "",
@@ -3954,7 +4176,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "10.4.1",
       "targets": [
         {
           "datasource": {
@@ -4013,8 +4235,7 @@
   ],
   "refresh": "",
   "revision": 1,
-  "schemaVersion": 38,
-  "style": "dark",
+  "schemaVersion": 39,
   "tags": [
     "main"
   ],
@@ -4114,7 +4335,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -4176,7 +4397,7 @@
     ]
   },
   "time": {
-    "from": "2018-01-01T00:00:00.000Z",
+    "from": "now-2y",
     "to": "now"
   },
   "timepicker": {
@@ -4196,6 +4417,6 @@
   "timezone": "",
   "title": "Activity View",
   "uid": "TfxgjgJZk",
-  "version": 3,
+  "version": 1,
   "weekStart": ""
 }

--- a/dashboards/iris/provider_view.json
+++ b/dashboards/iris/provider_view.json
@@ -25,7 +25,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 3,
   "links": [
     {
       "asDropdown": false,
@@ -47,6 +46,230 @@
   ],
   "liveNow": false,
   "panels": [
+    {
+      "datasource": {
+        "type": "mysql",
+        "uid": "P4815E41304F4136B"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "custom": {
+            "fillOpacity": 100,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "from": 0,
+                "result": {
+                  "color": "#f53535",
+                  "index": 0,
+                  "text": "0-10"
+                },
+                "to": 10
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 10,
+                "result": {
+                  "color": "#ec5d35",
+                  "index": 1,
+                  "text": "10-20"
+                },
+                "to": 20
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 20,
+                "result": {
+                  "color": "#e48134",
+                  "index": 2,
+                  "text": "20-30"
+                },
+                "to": 30
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 30,
+                "result": {
+                  "color": "#dca233",
+                  "index": 3,
+                  "text": "30-40"
+                },
+                "to": 40
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 40,
+                "result": {
+                  "color": "#d4bf32",
+                  "index": 4,
+                  "text": "40-50"
+                },
+                "to": 50
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 50,
+                "result": {
+                  "color": "#becc31",
+                  "index": 5,
+                  "text": "50-60"
+                },
+                "to": 60
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 60,
+                "result": {
+                  "color": "#96c430",
+                  "index": 6,
+                  "text": "60-70"
+                },
+                "to": 70
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 70,
+                "result": {
+                  "color": "#72bc2f",
+                  "index": 7,
+                  "text": "70-80"
+                },
+                "to": 80
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 80,
+                "result": {
+                  "color": "#50b42e",
+                  "index": 8,
+                  "text": "80-90"
+                },
+                "to": 90
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 90,
+                "result": {
+                  "color": "#32ac2d",
+                  "index": 9,
+                  "text": "90-100"
+                },
+                "to": 100
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 100,
+                "result": {
+                  "color": "#2fe4ff",
+                  "index": 10,
+                  "text": "100+"
+                }
+              },
+              "type": "range"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 17,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": false,
+        "rowHeight": 0.8,
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "dataset": "iris_cloud",
+          "datasource": {
+            "type": "mysql",
+            "uid": "P4815E41304F4136B"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "hide": false,
+          "rawQuery": true,
+          "rawSql": "SELECT\n  Date as \"time\",\n  Site,\n  SUM(CpuDuration)/SUM(WallDuration*CpuCount)*100 AS \"\"\nFROM VCombinedSummaries\nWHERE\n  $__timeFilter(Date) and Project in ($Project) and Site in ($Site) and VO in ($VO) and SourceSchema in ($Source) and VOGroup in ($VOGroup)\nGROUP BY 1,2\nORDER BY Date",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Job Time Ratios",
+      "type": "state-timeline"
+    },
     {
       "aliasColors": {
         "AENEAS": "#f58231",
@@ -918,7 +1141,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 11
       },
       "hiddenSeries": false,
       "id": 13,
@@ -938,7 +1161,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.4.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1965,7 +2188,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 23
       },
       "hiddenSeries": false,
       "id": 10,
@@ -1984,14 +2207,13 @@
       },
       "lines": false,
       "linewidth": 1,
-      "links": [],
       "nullPointMode": "null as zero",
       "options": {
         "alertThreshold": true
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.4.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2999,7 +3221,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 35
       },
       "hiddenSeries": false,
       "id": 4,
@@ -3016,7 +3238,6 @@
       },
       "lines": false,
       "linewidth": 1,
-      "links": [],
       "nullPointMode": "null as zero",
       "options": {
         "alertThreshold": true
@@ -3987,7 +4208,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 35
       },
       "hiddenSeries": false,
       "id": 6,
@@ -4002,7 +4223,6 @@
       },
       "lines": false,
       "linewidth": 1,
-      "links": [],
       "nullPointMode": "null as zero",
       "options": {
         "alertThreshold": true
@@ -4973,7 +5193,7 @@
         "h": 15,
         "w": 12,
         "x": 0,
-        "y": 33
+        "y": 44
       },
       "hiddenSeries": false,
       "id": 7,
@@ -4992,7 +5212,6 @@
       },
       "lines": false,
       "linewidth": 1,
-      "links": [],
       "nullPointMode": "null as zero",
       "options": {
         "alertThreshold": true
@@ -5160,10 +5379,9 @@
         "h": 15,
         "w": 12,
         "x": 12,
-        "y": 33
+        "y": 44
       },
       "id": 8,
-      "links": [],
       "pageSize": 16,
       "scroll": true,
       "showHeader": true,
@@ -5286,8 +5504,7 @@
   ],
   "refresh": "",
   "revision": 1,
-  "schemaVersion": 38,
-  "style": "dark",
+  "schemaVersion": 39,
   "tags": [
     "main"
   ],
@@ -5387,7 +5604,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -5449,7 +5666,7 @@
     ]
   },
   "time": {
-    "from": "2018-01-01T00:00:00.000Z",
+    "from": "now-2y",
     "to": "now"
   },
   "timepicker": {
@@ -5469,6 +5686,6 @@
   "timezone": "",
   "title": "Provider View",
   "uid": "TEXgjgJZk",
-  "version": 3,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
Resolves #161
Resolves GT-333

Added to activity and provider view in the dashboards as a colour coded table


For example:
![image](https://github.com/apel/grafana-dashboards/assets/115461530/d09cfd39-28be-48fe-b658-6beceb858c4e)
